### PR TITLE
feature: Add PathPaginator

### DIFF
--- a/examples/pagination.rs
+++ b/examples/pagination.rs
@@ -7,10 +7,13 @@ use vila::{Client, Request, RequestData};
 
 // Helpers
 fn extract_page_number(q: &PaginationType) -> Option<usize> {
-    let PaginationType::Query(v) = q;
-    v.first()
-        .map(|(_, v)| str::parse::<usize>(v).ok())
-        .flatten()
+    if let PaginationType::Query(v) = q {
+        v.first()
+            .map(|(_, v)| str::parse::<usize>(v).ok())
+            .flatten()
+    } else {
+        panic!("Unexpected paginator")
+    }
 }
 
 fn get_next_url(

--- a/tests/integration/pagination/mod.rs
+++ b/tests/integration/pagination/mod.rs
@@ -1,0 +1,2 @@
+mod path;
+mod query;

--- a/tests/integration/pagination/query.rs
+++ b/tests/integration/pagination/query.rs
@@ -1,0 +1,146 @@
+use crate::utils::matchers::MissingQuery;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use vila::pagination::*;
+use vila::{Client, Request, RequestData};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, Request as MockRequest, ResponseTemplate};
+
+#[derive(Serialize)]
+struct PaginationRequest {
+    page: Option<usize>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct PaginationResponse {
+    next_page: Option<usize>,
+    data: String,
+}
+
+impl Request for PaginationRequest {
+    type Data = Self;
+    type Response = PaginationResponse;
+
+    fn endpoint(&self) -> Cow<str> {
+        "/page".into()
+    }
+
+    fn data(&self) -> RequestData<&Self> {
+        RequestData::Query(self)
+    }
+}
+
+impl PaginatedRequest for PaginationRequest {
+    type Paginator = QueryPaginator<PaginationResponse>;
+    fn paginator(&self) -> Self::Paginator {
+        QueryPaginator::new(|_, r: &PaginationResponse| {
+            r.next_page
+                .map(|page| vec![("page".into(), page.to_string())])
+        })
+    }
+}
+
+#[tokio::test]
+async fn query_pagination() {
+    let server = MockServer::start().await;
+    let uri = server.uri();
+    let client = Client::new(&uri);
+
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .and(MissingQuery::new("page"))
+        .respond_with(|_: &MockRequest| {
+            let body = PaginationResponse {
+                next_page: Some(1),
+                data: "First!".into(),
+            };
+            ResponseTemplate::new(200).set_body_json(body)
+        })
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .and(query_param("page", "1"))
+        .respond_with(|_: &MockRequest| {
+            let body = PaginationResponse {
+                next_page: Some(2),
+                data: "Second!".into(),
+            };
+            ResponseTemplate::new(200).set_body_json(body)
+        })
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .and(query_param("page", "2"))
+        .respond_with(|_: &MockRequest| {
+            let body = PaginationResponse {
+                next_page: None,
+                data: "Last!".into(),
+            };
+            ResponseTemplate::new(200).set_body_json(body)
+        })
+        .mount(&server)
+        .await;
+
+    let mut response = client.send_paginated(&PaginationRequest { page: None });
+    assert_eq!(
+        response.next().await.unwrap().unwrap().data,
+        "First!".to_string()
+    );
+    assert_eq!(
+        response.next().await.unwrap().unwrap().data,
+        "Second!".to_string()
+    );
+    assert_eq!(
+        response.next().await.unwrap().unwrap().data,
+        "Last!".to_string()
+    );
+    assert!(response.next().await.is_none());
+}
+
+#[tokio::test]
+async fn can_overwrite_existing_query() {
+    let server = MockServer::start().await;
+    let uri = server.uri();
+    let client = Client::new(&uri);
+
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .and(query_param("page", "0"))
+        .respond_with(|_: &MockRequest| {
+            let body = PaginationResponse {
+                next_page: Some(1),
+                data: "First!".into(),
+            };
+            ResponseTemplate::new(200).set_body_json(body)
+        })
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .and(query_param("page", "1"))
+        .respond_with(|_: &MockRequest| {
+            let body = PaginationResponse {
+                next_page: Some(2),
+                data: "Second!".into(),
+            };
+            ResponseTemplate::new(200).set_body_json(body)
+        })
+        .mount(&server)
+        .await;
+
+    let mut response = client.send_paginated(&PaginationRequest { page: Some(0) });
+    assert_eq!(
+        response.next().await.unwrap().unwrap().data,
+        "First!".to_string()
+    );
+    assert_eq!(
+        response.next().await.unwrap().unwrap().data,
+        "Second!".to_string()
+    );
+}


### PR DESCRIPTION
PathPaginator is a Paginator that allows for dynamically changing the
path of a request in order to get all data
